### PR TITLE
Fix partial payload reads

### DIFF
--- a/cmd/bootstrapping.go
+++ b/cmd/bootstrapping.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -228,13 +229,12 @@ func readBootstrapMessage(conn net.Conn, b *common.Bootstrapper) {
 		return
 	}
 	payload := make([]byte, messageLength)
-	n, err := conn.Read(payload)
-
-	if int32(n) != messageLength {
-		return
-	}
+	n, err := io.ReadFull(conn, payload)
 	if err != nil {
 		common.SkipTcpClosePanic(fmt.Errorf("failed to read bootstrap message: %v", err))
+		return
+	}
+	if int32(n) != messageLength {
 		return
 	}
 	var peerMsg common.BootstrapMessage

--- a/p2p/p2p_transporter.go
+++ b/p2p/p2p_transporter.go
@@ -374,7 +374,7 @@ func (t *p2pTransporter) readDataRoutine(pid string, stream network.Stream) {
 			if err != nil {
 				common.Panic(fmt.Errorf("failed to read protobuf message: %v, from: %s", err, pid))
 			} else {
-				payloadWithTypePrefix = append(payloadWithTypePrefix, buf...)
+				payloadWithTypePrefix = append(payloadWithTypePrefix, buf[:readLength]...)
 			}
 			readBytes += readLength
 		}


### PR DESCRIPTION
## Summary
- Use `io.ReadFull` when reading bootstrap TCP payloads so partial reads do not drop valid messages.
- Append only the bytes actually read when accumulating p2p framed payloads.

Fixes #41 